### PR TITLE
Added python3 port of focal stack generation tool

### DIFF
--- a/utility/python/refocus.py
+++ b/utility/python/refocus.py
@@ -27,8 +27,8 @@ def refocus(light_field, calib_mat, output_folder, stack_size=10):
 
     for idx, disparity in enumerate(disparities):
         lfsize = (lf.shape[2], lf.shape[3])
-        uvcenter = np.asarray((np.asarray([lf.shape[0],lf.shape[1]])+1)/2) #Test this
-        image = np.zeros( lfsize + (3,)) #Test this
+        uvcenter = np.asarray((np.asarray([lf.shape[0],lf.shape[1]])+1)/2)
+        image = np.zeros( lfsize + (3,))
 
         for u in range(lf.shape[0]):
             for v in range(lf.shape[1]):

--- a/utility/python/refocus.py
+++ b/utility/python/refocus.py
@@ -14,7 +14,7 @@ def refocus(light_field, calib_mat, output_folder, stack_size=10):
         return
     K2 = mat[1]
     fxy = mat[2:4]
-    flens = max(fxy);
+    flens = max(fxy)
     fsubaperture = 521.4052 # pixel
     baseline = K2/flens*1e-3 # meters
 
@@ -42,11 +42,11 @@ def refocus(light_field, calib_mat, output_folder, stack_size=10):
                 image = image + shifted
 
         
-        image = image / np.prod([lf.shape[0], lf.shape[1]]);
+        image = image / np.prod([lf.shape[0], lf.shape[1]])
         image = np.uint8(image * 255.0)
 
         #Convert RGB to BGR (OpenCV assumes image to be BGR) and write output image
-        cv2.imwrite(output_folder + "/" + "{0:02d}".format(idx+1) + ".png", cv2.cvtColor(image, cv2.COLOR_RGB2BGR));
+        cv2.imwrite(output_folder + "/" + "{0:02d}".format(idx+1) + ".png", cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
 
 
 if __name__ == "__main__":

--- a/utility/python/refocus.py
+++ b/utility/python/refocus.py
@@ -1,0 +1,53 @@
+#! /usr/bin/python3
+
+import numpy as np
+import scipy.io
+import cv2
+import subpixel_shift
+
+def refocus(light_field, calib_mat, output_folder, stack_size=10):
+    #Load calibration parameters
+    mat = scipy.io.loadmat(calib_mat)
+    if 'IntParamLF' in mat:
+        mat = np.squeeze(mat['IntParamLF'])
+    else:
+        return
+    K2 = mat[1]
+    fxy = mat[2:4]
+    flens = max(fxy);
+    fsubaperture = 521.4052 # pixel
+    baseline = K2/flens*1e-3 # meters
+
+    depth_range = [0.5, 7]
+    disparity_range = (baseline*fsubaperture / depth_range)
+    disparities = np.linspace(disparity_range[0], disparity_range[1], num=stack_size)
+
+    #Read light field image according to instructions given at http://hazirbas.com/datasets/ddff12scene/
+    lf = np.load(light_field) / 255.0
+
+    for idx, disparity in enumerate(disparities):
+        lfsize = (lf.shape[2], lf.shape[3])
+        uvcenter = np.asarray((np.asarray([lf.shape[0],lf.shape[1]])+1)/2) #Test this
+        image = np.zeros( lfsize + (3,)) #Test this
+
+        for u in range(lf.shape[0]):
+            for v in range(lf.shape[1]):
+                shift = (uvcenter - np.asarray([u+1,v+1])) * disparity
+                shifted = subpixel_shift.subpixel_shift(
+                    np.fft.fft2(np.squeeze(lf[u,v]), axes=(0,1)),
+                    shift,
+                    lfsize[0],
+                    lfsize[1],
+                    1)
+                image = image + shifted
+
+        
+        image = image / np.prod([lf.shape[0], lf.shape[1]]);
+        image = np.uint8(image * 255.0)
+
+        #Convert RGB to BGR (OpenCV assumes image to be BGR) and write output image
+        cv2.imwrite(output_folder + "/" + "{0:02d}".format(idx+1) + ".png", cv2.cvtColor(image, cv2.COLOR_RGB2BGR));
+
+
+if __name__ == "__main__":
+    refocus('LF_0001.npy', '../../caldata/lfcalib/IntParamLF.mat', './')

--- a/utility/python/subpixel_shift.py
+++ b/utility/python/subpixel_shift.py
@@ -1,0 +1,42 @@
+#! /usr/bin/python3
+
+####################################################################
+# 2015.05.12 Hae-Gon Jeon
+# Accurate Depth Map Estimation from a Lenslet Light Field Camera
+# CVPR 2015
+# Ported to python3 by Sebastian Soyer
+# ACADEMIC USE ONLY
+####################################################################
+
+import numpy as np
+
+def subpixel_shift(f, delta, nr, nc, mode):
+    """Image shift with sub-pixel precision using phase theorem input.
+
+    Args:
+        f: fft of color image.
+        delta: 1X2 matrix for sub-pixel displacement.
+        nr - row size of input image.
+        nc - column size of input image.
+        mode - 1) color image, 2) gradient image.
+
+    Returns:
+        output: A sub-pixel shifted image
+
+    """
+
+    deltar = delta[0]
+    deltac = delta[1]
+    phase = 2
+
+
+    Nr = np.fft.ifftshift(range(int(-np.fix(nr/2)),int(np.ceil(nr/2))))
+    Nc = np.fft.ifftshift(range(int(-np.fix(nc/2)),int(np.ceil(nc/2))))
+    [Nc,Nr] = np.meshgrid(Nc,Nr)
+
+    result = np.fft.ifft2(f * np.tile(np.exp(1j*2*np.pi*(deltar*Nr/nr+deltac*Nc/nc))[:,:,np.newaxis], [1, 1, 3]), axes=(0,1)) * np.exp(-1j*phase)
+
+    if mode == 1:
+        return np.clip(abs(result), 0, 1)
+    else:
+        return abs(result)


### PR DESCRIPTION
I ported the matlab script for creating a focal stack from light field images to python. I figured this might fit well into the ddff-toolbox.
As the matlab version uses the fn_SubpixelShift function by Hae-Gon Jeon, this pull request also contains a port of this function to python.
In order to run the script, numpy, scipy and OpenCV are needed. Maybe it might be helpful to add a requirements.txt somewhere.

If you are interested please have a look and tell me what you think!